### PR TITLE
feat: add `plot()` method for `SlopeFit` objects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 [compat]
 Aqua = "0.8"
 CxxWrap = "0.17.0"
-LinearAlgebra = "1.11.0"
+LinearAlgebra = "1.10.9"
 Random = "1.10.9"
 SparseArrays = "1.10.0"
 Test = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -3,12 +3,18 @@ uuid = "e3f974f6-674d-4b8e-a3d1-5850677db852"
 authors = ["Johan Larsson <jolars@posteo.com> and contributors"]
 version = "1.0.0"
 
+[extensions]
+PlotSLOPE = "Plots"
+
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 slope_jll = "baac1969-1582-5600-b38b-7408c9d44009"
+
+[weakdeps]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]
 Aqua = "0.8"
@@ -17,12 +23,13 @@ LinearAlgebra = "1.11.0"
 Random = "1.10.9"
 SparseArrays = "1.10.0"
 Test = "1.6"
-julia = "1.6"
+julia = "1.9"
 slope_jll = "1.0.0"
+Plots = "1.40.13"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test"]
+test = ["Aqua", "Test", "Plots"]

--- a/ext/PlotSLOPE/PlotSLOPE.jl
+++ b/ext/PlotSLOPE/PlotSLOPE.jl
@@ -1,0 +1,128 @@
+module PlotSLOPE
+
+using SLOPE
+using Plots
+
+"""
+    plot(fit::SLOPE.SlopeFit; xvar::Symbol=:α, layout=nothing, kwargs...)
+
+Plot the coefficient paths from a SLOPE model regularization path.
+
+This function visualizes how the coefficients change along the regularization path,
+allowing you to see which variables enter the model and how their effects change
+as the regularization strength varies.
+
+For multinomial models (when fit.m > 1), this creates a multi-panel plot with
+one panel per response class.
+
+# Arguments
+- `fit::SLOPE.SlopeFit`: A fitted SLOPE model object containing the regularization path
+- `xvar::Symbol=:α`: Variable for the x-axis, options:
+  - `:α`: Plot against the regularization parameter alpha (default)
+  - `:step`: Plot against the step number in the regularization path
+- `layout`: Layout for multi-class plots, e.g., (rows, cols). Default is (m, 1)
+  for m classes.
+
+# Keyword Arguments
+- `kwargs...`: Additional arguments passed to `Plots.plot()`, such as:
+  - `title`: Title for the plot
+  - `legend`: Legend position (default: `:none`)
+  - `lw`: Line width
+  - `color`: Color scheme
+
+# Returns
+A Plots.jl plot object showing the coefficient paths
+"""
+function Plots.plot(fit::SLOPE.SlopeFit; xvar::Symbol=:α, layout=nothing, kwargs...)
+  coefs = fit.coefficients
+  path_length = length(coefs)
+  α = fit.α
+
+  p, m = size(coefs[1])
+  coef_matrix = zeros(p, path_length)
+
+  for (i, coef) in enumerate(coefs)
+    for row in 1:p
+      val = coef[row, 1]
+      coef_matrix[row, i] = val
+    end
+  end
+
+  plot_defaults = Dict{Symbol,Any}(
+    :xlabel => String(xvar),
+    :ylabel => "β",
+    :legend => :none,
+  )
+
+  if xvar == :α
+    plot_defaults[:xlabel] = "α"
+    plot_defaults[:xflip] = true
+    plot_defaults[:xscale] = :ln
+    x_values = α
+  elseif xvar == :step
+    plot_defaults[:xlabel] = "Step"
+    x_values = collect(1:path_length)
+  end
+
+  plot_options = merge(plot_defaults, Dict(kwargs))
+
+  # plt = Plots.plot(
+  #   x_values,
+  #   coef_matrix';
+  #   plot_options...
+  # )
+
+  if m == 1
+    coef_matrix = zeros(p, path_length)
+
+    for (i, coef) in enumerate(coefs)
+      for row in 1:p
+        coef_matrix[row, i] = coef[row, 1]
+      end
+    end
+
+    plt = Plots.plot(
+      x_values,
+      coef_matrix';
+      plot_options...
+    )
+
+    return plt
+  else
+    plots = []
+
+    for class in 1:m
+      coef_matrix = zeros(p, path_length)
+
+      for (i, coef) in enumerate(coefs)
+        for row in 1:p
+          coef_matrix[row, i] = coef[row, class]
+        end
+      end
+
+      class_options = copy(plot_options)
+      class_options[:title] = "Class $class"
+
+      plt = Plots.plot(
+        x_values,
+        coef_matrix';
+        class_options...
+      )
+
+      push!(plots, plt)
+    end
+
+    if isnothing(layout)
+      layout = (m, 1)
+    end
+
+    final_plot = Plots.plot(plots..., layout=layout)
+    return final_plot
+  end
+
+  return plt
+end
+
+export plot
+
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -1,0 +1,46 @@
+using SLOPE
+using Test
+using Plots
+using Random
+
+@testset "Univariate Family Plot" begin
+  n = 3
+  p = 2
+
+  x = [1.1 2.3; 0.5 1.5; 0.5 0.2]
+  β = [1.0, 2.0]
+  y = x * β
+
+  lambda = [1.0, 1.0]
+
+  res = slope(x, y)
+
+  plt = plot(res)
+
+  @test !isnothing(plt)
+end
+
+@testset "Multinomial Family Plot" begin
+  Random.seed!(1)
+
+  n = 100
+  p = 3
+  m = 4
+
+  x = rand(n, p)
+
+  β = rand(p, m)
+  η = x * β + randn(n, m)
+  Y = exp.(η) ./ sum(exp.(η), dims=2)
+  y = Vector{Int}(undef, n)
+
+  for i in 1:n
+    y[i] = argmax(Y[i, :])
+  end
+
+  res = slope(x, y, loss="multinomial")
+
+  plt = plot(res)
+
+  @test plt isa Plots.Plot
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,10 @@ using Aqua
     include("multinomial.jl")
   end
 
+  @testset "Plots" begin
+    include("plots.jl")
+  end
+
   @testset "Aqua" begin
     Aqua.test_all(SLOPE)
   end


### PR DESCRIPTION
This PR implements simple plotting of regularization paths for both univariate and multivariate (multinomial logistic) loss.